### PR TITLE
[ATSCALE-17437] - Fixed Inconsistent Metadata Retrieval in Alation During first time Project Extraction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ This project contains the code to create an Alation OCF Connector to AtScale. Us
 1. In IntelliJ, Execute Maven Goal: `mvn clean`
 2. In IntelliJ, Execute Maven Goal: `mvn compile`
 3. In IntelliJ, Execute Maven Goal: `mvn assembly:single`
-4. From the console in the project directory, run `./package_connector.sh -m biconnector -j target/biconnector-1.1.0-jar-with-dependencies.jar -f Dockerfile`
+4. From the console in the project directory, run `./package_connector.sh -m biconnector -j target/biconnector-1.1.1-jar-with-dependencies.jar -f Dockerfile`
 5. If successful, it will produce a file named `atscale-alation-connector-x.x.x.zip`

--- a/package_connector.sh
+++ b/package_connector.sh
@@ -83,6 +83,6 @@ echo " Step 8: Removing temp files..."
 rm -f ${connectorName}.img ${driverName} MANIFEST.MF
 
 echo " Step 9: Renaming zip file..."
-mv ${connectorName}.zip "atscale-alation-connector-1.1.0.zip"
+mv ${connectorName}.zip "atscale-alation-connector-1.1.1.zip"
 
 echo "Packaging module ${MODULE} completed."

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <groupId>bi</groupId>
     <artifactId>biconnector</artifactId>

--- a/src/main/java/atscale/biconnector/datasource/AtScaleBIDatasource.java
+++ b/src/main/java/atscale/biconnector/datasource/AtScaleBIDatasource.java
@@ -42,7 +42,7 @@ public class AtScaleBIDatasource
 
     private static final Logger LOGGER = Logger.getLogger(AtScaleBIDatasource.class);
     private final Map<Integer, String> dataTypeVsNameMap = new HashMap<>();
-    private static final String VERSION = "1.1.0";
+    private static final String VERSION = "1.1.1";
     private static final String FOLDER_ID_1 = "folder_id_1";
     private static final String TEST_FOLDER_1 = "Test Folder 1";
 

--- a/src/main/java/atscale/biconnector/datasource/AtScaleBIDatasource.java
+++ b/src/main/java/atscale/biconnector/datasource/AtScaleBIDatasource.java
@@ -267,7 +267,7 @@ public class AtScaleBIDatasource
 
         folderList.forEach(
                 folder -> {
-                    if (folder.getBiObjectType().equalsIgnoreCase("Project")) {
+                    if (folder.getBiObjectType().equalsIgnoreCase("Project") || folder.getBiObjectType().equalsIgnoreCase("Workbook")) {
                         filteredCatalogNames.add(folder.getName());
                     } else if (folder.getBiObjectType().equalsIgnoreCase("Cube")) {
                         filteredCubeNames.add(folder.getName());


### PR DESCRIPTION

#### Tickets
- [ATSCALE-17437](https://atscale.atlassian.net/browse/ATSCALE-17437)

#### Description
- Fixed Inconsistent Metadata Retrieval in Alation During first time Project Extraction.

- When we click on "Get Project List," it fetches the project list correctly. However, when attempting to extract metadata for a   selected project, the extraction process runs successfully, but we do not see any metadata.

- Upon further investigation, we have identified that this issue occurs specifically when we change the organization ID and then attempt to extract metadata for a particular project. Strangely, when we click on "Run Extraction" again, it works as expected, and we receive all the fields for the selected project.

- After diving deeper into the codebase, we discovered that we are filtering out catalogs with the biObjectType=Project attribute. However, during the initial extraction for a selected project, we receive biObjectType=Workbook. Consequently, our connector's filter does not filter out catalogs, resulting in the absence of fields.

#### Testing
- The testing has already been done.

[ATSCALE-17437]: https://atscale.atlassian.net/browse/ATSCALE-17437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ